### PR TITLE
fix(Compendium):kobold Exposed Reactor corrected typo

### DIFF
--- a/frames.json
+++ b/frames.json
@@ -243,7 +243,7 @@
               "engineering",
               "skill_check"
             ],
-            "detail": "The Atlas takes +1 difficulty on Engineering checks and saves."
+            "detail": "The Kobold takes +1 difficulty on Engineering checks and saves."
           }
         ]
       }


### PR DESCRIPTION
# Description
Fixes Typo in the detail of Kobold's Exposed Reactor, referring to Atlas.

## Issue Number
Closes [CompCon #1652](https://github.com/massif-press/compcon/issues/1652)

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)