### PR TITLE
fix(Mod):add added_tags to Supermassive Mod

### DIFF
--- a/mods.json
+++ b/mods.json
@@ -17,6 +17,15 @@
       {
         "id": "tg_unique"
       }
+    ],
+    "added_tags": [
+      {
+        "id": "tg_overkill"
+      },
+      {
+        "id": "tg_knockback",
+        "val": 1
+      }
     ]
   },
   {


### PR DESCRIPTION
# Description
Included some baseline `added_tags` to the Caliban's Supermassive Mod. It appears to always add Overkill and at least Knockback 1, so I added those to its `added_tags`.  I can understand arguments for excluding `added_tags` altogether since they're modal for the mod, but even if mods lack the profiles that weapons can possess, I still feel that some baseline tags should be included for user convenience in Active Mode.

## Issue Number
None at time of writing.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)