### PR TITLE
fix(Compendium):zheng CP made protocol + passive action

### DIFF
--- a/frames.json
+++ b/frames.json
@@ -443,9 +443,15 @@
       "description": "Surviving mostly on colonial rations and an increasingly radioactive air supply, Xiaoli scavenged materials from a dying ship to create modifications that gave her mech unprecedented unarmed striking power.",
       "active_name": "Xiaoli’s Ingenuity",
       "active_effect": "For the rest of the scene, this system gains 6 charges (you can use a die to track this). Expend a charge to use XIAOLI’S TENACITY again, ignoring the 1/Turn limit. You may spend any number of charges a turn. At the end of each turn, you regain a charge for each unique target (character, object, or piece of terrain) you damaged with this action, to a maximum of 6.",
-      "activation": "Free",
+      "activation": "Protocol",
       "passive_name": "Xiaoli's Tenacity",
-      "passive_effect": "1/turn as a free action, you may move up to 3 spaces then deal 2 Kinetic to any adjacent character or 10 Kinetic AP to an object or piece of terrain. This movement prompts engagement and does not ignore reactions.<br>If this damage destroys an object or piece of terrain, it explodes, dealing 1d6 Kinetic to all adjacent characters other than you and knocking them back 1 space.",
+      "passive_actions": [
+        {
+          "name": "Xiaoli's Tenacity",
+          "activation": "Free",
+          "detail": "1/turn as a free action, you may move up to 3 spaces then deal 2 Kinetic to any adjacent character or 10 Kinetic AP to an object or piece of terrain. This movement prompts engagement and does not ignore reactions.<br>If this damage destroys an object or piece of terrain, it explodes, dealing 1d6 Kinetic to all adjacent characters other than you and knocking them back 1 space."
+        }
+      ],
       "counters": [
         {
           "id": "ctr_xiaoli_type_cqb_suite",


### PR DESCRIPTION
# Description
This change amends the activation of the Zheng's Core Passive to be a Protocol, as well as moves Xiaoli's Tenacity into a Free Action object.  Followed pattern of the Pegasus Ushabti Omnigun Core Passive and omitted the "frequency: 1/turn" field since it may cause issues in Active Mode when the Zheng activates Xiaoli's Ingenuity.

## Issue Number
Closes [CompCon #1678](https://github.com/massif-press/compcon/issues/1678)

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)