### PR TITLE
fix(data): warp rifle effect made on-hit

### DIFF
--- a/weapons.json
+++ b/weapons.json
@@ -400,7 +400,8 @@
     "source":"HA",
     "license":"SUNZI",
     "license_level":2,
-    "effect":"The target must pass an ENGINEERING save or be teleported a number of spaces equal to the damage you dealt with this weapon (including bonus damage, etc.; no more than 10 spaces), in a direction of your choice. They must end in a free, valid space.",
+    "effect": "",
+    "on_hit":"The target must pass an ENGINEERING save or be teleported a number of spaces equal to the damage you dealt with this weapon (including bonus damage, etc.; no more than 10 spaces), in a direction of your choice. They must end in a free, valid space.",
     "description":"Es una abominación. Dicen que \"es como los arados de las espadas; tú también debes aprender a defender tu hogar ”. Ptah, escupí su lógica de espada. Ni siquiera sabíamos de los arados compartidos antes de convertirlos en espadas, y éramos felices.<br>Hiciste la puerta, la abriste. No es nuestra responsabilidad cerrarla.<br>[It is an abomination. They say “it is like plowshares to swords; you too must learn to defend your home.” Ptah, I spit on their blade-law. We did not even know of plowshares before they beat them into swords, and we were happy.<br>You made the door, you swung it open — it is not our responsibility to close it.]",
     "sp":1
   },


### PR DESCRIPTION
# Description
Correctly sets the Warp Rifle's effect as On-Hit instead of a blanket effect.  Relevant in case some mod or other effect lets the rifle deal damage on a miss.

## Issue Number
Closes #20

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)