### PR TITLE
Fix/no module

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ const data = {
   frames: require('./lib/frames.json'),
   // manufacturers: require('./lib/manufacturers.json'),
   mods: require('./lib/mods.json'),
-  pilot_gear: require('./lib/pilot_gear.json'),
+  // pilot_gear: require('./lib/pilot_gear.json'),
   // reserves: require('./lib/reserves.json'),
   // sitreps: require('./lib/sitreps.json'),
   // skills: require('./lib/skills.json'),

--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
   "version": "1.2.1",
   "description": "Player-facing COMP/CON data for 'The Long Rim', a setting for the LANCER TTRPG",
   "main": "index.js",
-  "type": "module",
   "scripts": {
     "build": "node ./scripts/build.js",
     "cleanup": "node ./scripts/cleanup.js",

--- a/scripts/_cleanup/decap.js
+++ b/scripts/_cleanup/decap.js
@@ -27,7 +27,6 @@ const decap = (commit) => {
   const files = fs.readdirSync(folderPath);
 
   files.forEach((file) => {
-    console.log(file);
     if (ignore.some((x) => x === file)) return;
     const filePath = path.join(folderPath, file);
 

--- a/scripts/_cleanup/decap.js
+++ b/scripts/_cleanup/decap.js
@@ -1,7 +1,7 @@
 #!/usr/bin/node
 
-import fs from 'fs';
-import path from 'path';
+const fs = require('fs');
+const path = require('path');
 
 const folderPath = './lib';
 const ignore = ['manufacturers.json', 'lcp_manifest.json'];
@@ -59,4 +59,4 @@ const decap = (commit) => {
   if (commit) console.log(`fixed: ${fixed} entries in ${files.length} files`);
 };
 
-export default decap;
+module.exports = decap;

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -1,6 +1,6 @@
-import zl from 'zip-lib';
+const zl = require('zip-lib');
 
-import info from '../package.json' assert { type: 'json' };
+const info = require('../package.json');
 
 const name = info.name.split('/').pop();
 

--- a/scripts/cleanup.js
+++ b/scripts/cleanup.js
@@ -1,6 +1,6 @@
 #!/usr/bin/node
-import readline from 'readline';
-import decap from './_cleanup/decap.js';
+const readline = require('readline');
+const decap = require('./_cleanup/decap.js');
 
 const rl = readline.createInterface({
   input: process.stdin,

--- a/scripts/test.js
+++ b/scripts/test.js
@@ -1,4 +1,4 @@
-import * as fs from 'fs';
+const fs = require('fs');
 var currentDir = process.cwd();
 var files = fs.readdirSync('./lib');
 let contents = ""


### PR DESCRIPTION
# Description
Removes the `"type": "module"` flag from the `package.json` file. This package's `index.js` is not written to be an ES6 module due to its use of `require`, and as such it encounters errors when imported to other projects.