### PR TITLE
Add AI tag text to Didymos

### DIFF
--- a/lib/systems.json
+++ b/lib/systems.json
@@ -381,6 +381,7 @@
     "source": "HORUS",
     "license": "Lich",
     "license_level": 3,
+    "effect": "Your mech gains the AI tag and the Time Split Quick Tech action.",
     "actions": [
       {
         "name": "Time Split",


### PR DESCRIPTION
Adds missing effect text from most NHP systems that clarifies that they properly provide the Mech itself the AI tag, which is what actually lets you hand control over, rather than having a system with the AI tag. 

Resolves https://github.com/massif-press/compcon/issues/2360
Same issue as https://github.com/massif-press/lancer-data/pull/195, but for the Long Rim LCP